### PR TITLE
Add team section with carousel and cards

### DIFF
--- a/src/app/components/Footer.jsx
+++ b/src/app/components/Footer.jsx
@@ -1,0 +1,14 @@
+export default function Footer() {
+  return (
+    <footer className="w-full bg-black text-gray-400 py-6 flex flex-col items-center border-t border-blue-900/30 mt-16">
+      <div className="text-sm mb-2">&copy; {new Date().getFullYear()} Sci-Fi Innovation Club | Chandigarh University</div>
+      <div className="flex gap-4">
+        <a href="/" className="hover:text-blue-400 transition">Home</a>
+        <a href="/about" className="hover:text-blue-400 transition">About</a>
+        <a href="/events" className="hover:text-blue-400 transition">Events</a>
+        <a href="/team" className="hover:text-blue-400 transition">Team</a>
+      </div>
+      <div className="mt-2 text-xs text-gray-600">Made with <span className="text-blue-400">&#10084;</span> by the Sci-Fi Innovation Club</div>
+    </footer>
+  );
+}

--- a/src/app/components/Navbar.jsx
+++ b/src/app/components/Navbar.jsx
@@ -15,7 +15,7 @@ const Navbar = () => {
     { name: 'Home', href: '/' },
     { name: 'About Us', href: '/about' },
     { name: 'Events', href: '/events' },
-    { name: 'Team', href: '#team' },
+    { name: 'Team', href: '/team' },
     { name: 'Contact', href: '#contact' },
   ];
 

--- a/src/app/components/TeamCard.jsx
+++ b/src/app/components/TeamCard.jsx
@@ -1,0 +1,74 @@
+export default function TeamCard({ member }) {
+  return (
+  <div className="bg-gradient-to-br from-gray-800/50 to-gray-900/50 p-6 rounded-xl border border-blue-500/20 backdrop-blur-sm hover:border-blue-500/40 transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/25 group w-full max-w-[320px] md:w-[320px] md:h-[455px] flex flex-col justify-between">
+      {/* Profile Image */}
+      <div className="relative mb-6">
+        <div className="w-32 h-32 mx-auto rounded-full overflow-hidden border-4 border-gradient-to-r from-blue-400 to-purple-400 p-1">
+          <div className="w-full h-full rounded-full overflow-hidden">
+            <img
+              src={member.image}
+              alt={member.name}
+              className="w-full h-full object-cover"
+            />
+          </div>
+        </div>
+        {/* Floating badge */}
+        <div className="absolute -top-2 -right-2 w-8 h-8 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full flex items-center justify-center">
+          <span className="text-white text-xs font-bold">⭐</span>
+        </div>
+      </div>
+
+      {/* Member Info */}
+      <div className="text-center mb-4">
+        <h3 className="text-xl font-bold text-white mb-2">{member.name}</h3>
+        <p className="text-blue-400 font-medium mb-3">{member.role}</p>
+        <p className="text-gray-300 text-sm leading-relaxed mb-4">
+          {member.description}
+        </p>
+      </div>
+
+      {/* Specialties */}
+      <div className="mb-6">
+        <h4 className="text-sm font-semibold text-gray-400 mb-2">Specialties:</h4>
+        <div className="flex flex-wrap gap-2 justify-center">
+          {member.specialties.map((specialty, idx) => (
+            <span
+              key={idx}
+              className="px-2 py-1 bg-blue-500/20 text-blue-300 text-xs rounded-full border border-blue-500/30"
+            >
+              {specialty}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Social Links */}
+      <div className="flex justify-center space-x-4 mt-auto">
+        {/* LinkedIn Link */}
+        <a
+          href={`https://linkedin.com/in/${member.linkedin}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-center w-10 h-10 bg-blue-600/20 hover:bg-blue-600/40 rounded-full transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/25 group"
+          aria-label={`${member.name}'s LinkedIn Profile`}
+        >
+          <svg className="w-5 h-5 text-blue-400 group-hover:text-blue-300" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+          </svg>
+        </a>
+        {/* GitHub Link */}
+        <a
+          href={`https://github.com/${member.github}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center justify-center w-10 h-10 bg-gray-600/20 hover:bg-gray-600/40 rounded-full transition-all duration-300 hover:shadow-lg hover:shadow-gray-500/25 group"
+          aria-label={`${member.name}'s GitHub Profile`}
+        >
+          <svg className="w-5 h-5 text-gray-400 group-hover:text-gray-300" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+          </svg>
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/TeamCarousel.jsx
+++ b/src/app/components/TeamCarousel.jsx
@@ -1,0 +1,88 @@
+"use client";
+import React, { useState, useEffect } from "react";
+import TeamCard from "./TeamCard";
+import teamData from "../team/data.json";
+
+export default function TeamCarousel() {
+  // Use the same priority sorting as team page
+  const rolePriority = [
+    "Faculty Advisor",
+    "Faculty Co Advisor",
+    "Secretary",
+    "Joint Secretary"
+  ];
+  const teamMembers = [...teamData.members].sort((a, b) => {
+    const aIdx = rolePriority.findIndex(role => a.role.toLowerCase() === role.toLowerCase());
+    const bIdx = rolePriority.findIndex(role => b.role.toLowerCase() === role.toLowerCase());
+    if (aIdx === -1 && bIdx === -1) return 0;
+    if (aIdx === -1) return 1;
+    if (bIdx === -1) return -1;
+    return aIdx - bIdx;
+  });
+
+  const [current, setCurrent] = useState(0);
+  const total = teamMembers.length;
+
+  // Responsive number of cards
+  const [cardsToShow, setCardsToShow] = useState(1);
+  useEffect(() => {
+    function handleResize() {
+      if (window.innerWidth >= 1024) setCardsToShow(3); // desktop
+      else if (window.innerWidth >= 768) setCardsToShow(2); // tablet
+      else setCardsToShow(1); // mobile
+    }
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrent(prev => (prev + cardsToShow) % total);
+    }, 3500);
+    return () => clearInterval(interval);
+  }, [total, cardsToShow]);
+
+  const prevMember = () => setCurrent((current - cardsToShow + total) % total);
+  const nextMember = () => setCurrent((current + cardsToShow) % total);
+
+  // Get the slice of members to show
+  const visibleMembers = Array(cardsToShow).fill(0).map((_, i) => teamMembers[(current + i) % total]);
+
+  return (
+  <section className="w-full max-w-5xl mx-auto py-12 flex flex-col items-center">
+      <h2 className="text-4xl font-bold mb-6 text-yellow-400">Meet the Team</h2>
+      <div className="relative w-full flex items-center justify-center">
+        <button
+          onClick={prevMember}
+          className="absolute left-0 top-1/2 -translate-y-1/2 bg-gray-800 text-white px-3 py-2 rounded-full shadow hover:bg-cyan-400 hover:text-black transition"
+          aria-label="Previous"
+        >
+          &#8592;
+        </button>
+        <div className="w-full flex items-center justify-center gap-8">
+          {visibleMembers.map((member, idx) => (
+            <TeamCard key={idx} member={member} />
+          ))}
+        </div>
+        <button
+          onClick={nextMember}
+          className="absolute right-0 top-1/2 -translate-y-1/2 bg-gray-800 text-white px-3 py-2 rounded-full shadow hover:bg-cyan-400 hover:text-black transition"
+          aria-label="Next"
+        >
+          &#8594;
+        </button>
+      </div>
+      <div className="flex gap-2 mt-4 justify-center">
+        {teamMembers.map((_, idx) => (
+          <button
+            key={idx}
+            onClick={() => setCurrent(idx)}
+            className={`w-3 h-3 rounded-full ${current === idx ? "bg-cyan-400" : "bg-gray-600"}`}
+            aria-label={`Go to member ${idx + 1}`}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -7,6 +7,9 @@ import StarField from './components/StarField';
 import ParticleEffect from './components/ParticleEffect';
 import About from './about/page';
 import EventsPage from './events/page';
+import GalleryCarousel from './components/GalleryCarousel';
+import TeamCarousel from './components/TeamCarousel';
+import Footer from './components/Footer';
 
 
 export default function Page() {
@@ -25,8 +28,10 @@ export default function Page() {
       ) : (
         <Hero />
       )}
-      <About />
-      <EventsPage />
+  <About />
+  <EventsPage />
+  <TeamCarousel />
+  <Footer />
     </main>
   );
 }

--- a/src/app/team/data.json
+++ b/src/app/team/data.json
@@ -1,0 +1,31 @@
+{
+  "members": [
+    {
+      "name": "Krish Gauttam",
+      "role": "Joint Secretary",
+      "image": "https://avatars.githubusercontent.com/u/12345678?v=4",
+      "linkedin": "krish-177a5a276",
+      "github": "Krish-Gauttam",
+      "description": "Passionate about sci-fi and technology, leading innovation at the club.",
+      "specialties": ["React", "Next.js", "UI/UX"]
+    },
+    {
+      "name": "Ashish Singh",
+      "role": "Secretary",
+      "image": "https://avatars.githubusercontent.com/u/87654321?v=4",
+      "linkedin": "rishi-raj-gautam-232221276",
+      "github": "rishi-raj-gautam",
+      "description": "Creative thinker and organizer, driving club events and outreach.",
+      "specialties": ["Event Management", "Design", "Community"]
+    },
+    {
+      "name": "Dr. Sartajvir Singh Dhillon",
+      "role": "Faculty Advisor",
+      "image": "https://media.licdn.com/dms/image/C4D03AQFQw8w8w8w8w8/profile-displayphoto-shrink_200_200/0?e=1699488000&v=beta&t=xyz",
+      "linkedin": "sartajvir",
+      "github": "",
+      "description": "Guiding the club with expertise in science and innovation.",
+      "specialties": ["Mentorship", "Research", "Leadership"]
+    }
+  ]
+}

--- a/src/app/team/page.jsx
+++ b/src/app/team/page.jsx
@@ -1,0 +1,37 @@
+
+import Navbar from "../components/Navbar";
+import TeamCard from "../components/TeamCard";
+import teamData from "./data.json";
+
+export default function TeamPage() {
+  // Priority order for roles
+  const rolePriority = [
+    "Faculty Advisor",
+    "Faculty Co Advisor",
+    "Secretary",
+    "Joint Secretary"
+  ];
+
+  // Sort members by role priority, then others (team leads) at the end
+  const teamMembers = [...teamData.members].sort((a, b) => {
+    const aIdx = rolePriority.findIndex(role => a.role.toLowerCase() === role.toLowerCase());
+    const bIdx = rolePriority.findIndex(role => b.role.toLowerCase() === role.toLowerCase());
+    if (aIdx === -1 && bIdx === -1) return 0; // both are team leads or other
+    if (aIdx === -1) return 1; // a is team lead, b is priority
+    if (bIdx === -1) return -1; // b is team lead, a is priority
+    return aIdx - bIdx;
+  });
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen bg-black text-white px-4 py-12 flex flex-col items-center mt-16">
+        <h1 className="text-3xl font-bold mb-8 text-yellow-500">Our Team</h1>
+        <section className="w-full max-w-4xl grid grid-cols-1 md:grid-cols-3 gap-32">
+          {teamMembers.map((member, idx) => (
+            <TeamCard key={idx} member={member} />
+          ))}
+        </section>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
Introduces a new team section with a carousel and individual team member cards. Adds TeamCard, TeamCarousel, and supporting data for team members. Updates Navbar to link to the new /team page, and integrates TeamCarousel and Footer into the main page. Also adds a dedicated /team page displaying all members sorted by role priority.